### PR TITLE
fix: add the 'width' property to the MUI drawer configuration to prevent sidebar overflow

### DIFF
--- a/frontend/views/Overview.tsx
+++ b/frontend/views/Overview.tsx
@@ -156,9 +156,10 @@ const Overview = () => {
       <Box>
         <Drawer
           sx={{
-            width: 380,
+            width: 402,
             flexShrink: 0,
             "& .MuiDrawer-paper": {
+              width: 402,
               boxSizing: "border-box",
             },
           }}
@@ -219,7 +220,12 @@ const Overview = () => {
                   <ListItemIcon>
                     <QueueIcon />
                   </ListItemIcon>
-                  <ListItemText primary={queue.QueueName} />
+                  <ListItemText primary={queue.QueueName} primaryTypographyProps={{
+                    style: {
+                      whiteSpace: "pre-wrap",
+                      overflowWrap: "break-word",
+                    }
+                  }} />
                 </ListItemButton>
               </ListItem>
             ))}


### PR DESCRIPTION
After:
![Screenshot 2023-09-07 at 20 16 11](https://github.com/PacoVK/sqs-admin/assets/112934187/7cbeea3e-6183-47d4-9f81-b4d40cd0e7ee)
Before:
![Screenshot 2023-09-07 at 20 25 01](https://github.com/PacoVK/sqs-admin/assets/112934187/66dcf357-af1f-4d7c-b657-8541f342af12)
