### PR TITLE
feat(ui): make the queue sidebar resizable

### DIFF
--- a/frontend/components/SidebarResizeHandle.test.tsx
+++ b/frontend/components/SidebarResizeHandle.test.tsx
@@ -1,0 +1,231 @@
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import Box from "@mui/material/Box";
+import SidebarResizeHandle from "./SidebarResizeHandle";
+import useResizableSidebar, {
+  DEFAULT_SIDEBAR_WIDTH,
+  MAX_SIDEBAR_WIDTH,
+  MIN_SIDEBAR_WIDTH,
+  SIDEBAR_WIDTH_VAR,
+} from "../hooks/useResizableSidebar";
+
+const STORAGE_KEY = "sqs-admin.sidebarWidth";
+
+const Harness = () => {
+  const { width, resizing, containerRef, separatorProps } =
+    useResizableSidebar();
+  return (
+    <Box
+      ref={containerRef}
+      data-testid="container"
+      sx={{ display: "flex", [SIDEBAR_WIDTH_VAR]: `${width}px` }}
+    >
+      <SidebarResizeHandle resizing={resizing} {...separatorProps} />
+    </Box>
+  );
+};
+
+const separator = () =>
+  screen.getByRole("separator", { name: "Resize queue list" });
+
+const currentWidth = () => Number(separator().getAttribute("aria-valuenow"));
+
+const cssWidth = () =>
+  screen.getByTestId("container").style.getPropertyValue(SIDEBAR_WIDTH_VAR);
+
+const drag = (fromX: number, toX: number) => {
+  fireEvent(
+    separator(),
+    new MouseEvent("pointerdown", {
+      clientX: fromX,
+      button: 0,
+      bubbles: true,
+    }),
+  );
+  act(() => {
+    window.dispatchEvent(
+      new MouseEvent("pointermove", { clientX: toX, bubbles: true }),
+    );
+    window.dispatchEvent(
+      new MouseEvent("pointerup", { clientX: toX, bubbles: true }),
+    );
+  });
+};
+
+const setViewportWidth = (viewportWidth: number) => {
+  Object.defineProperty(window, "innerWidth", {
+    value: viewportWidth,
+    configurable: true,
+    writable: true,
+  });
+  act(() => {
+    window.dispatchEvent(new Event("resize"));
+  });
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  setViewportWidth(1024);
+});
+
+describe("<SidebarResizeHandle /> spec", () => {
+  it("starts at the default width", () => {
+    render(<Harness />);
+
+    expect(currentWidth()).toBe(DEFAULT_SIDEBAR_WIDTH);
+    expect(cssWidth()).toBe(`${DEFAULT_SIDEBAR_WIDTH}px`);
+  });
+
+  it("exposes the resize bounds to assistive technology", () => {
+    render(<Harness />);
+
+    expect(separator()).toHaveAttribute("aria-orientation", "vertical");
+    expect(separator()).toHaveAttribute(
+      "aria-valuemin",
+      String(MIN_SIDEBAR_WIDTH),
+    );
+    expect(separator()).toHaveAttribute(
+      "aria-valuemax",
+      String(MAX_SIDEBAR_WIDTH),
+    );
+  });
+
+  it("restores the persisted width on mount", () => {
+    window.localStorage.setItem(STORAGE_KEY, "300");
+
+    render(<Harness />);
+
+    expect(currentWidth()).toBe(300);
+    expect(cssWidth()).toBe("300px");
+  });
+
+  it("ignores a corrupted persisted width", () => {
+    window.localStorage.setItem(STORAGE_KEY, "not-a-width");
+
+    render(<Harness />);
+
+    expect(currentWidth()).toBe(DEFAULT_SIDEBAR_WIDTH);
+  });
+
+  it("clamps a persisted width that no longer fits the viewport", () => {
+    window.localStorage.setItem(STORAGE_KEY, "5000");
+
+    render(<Harness />);
+
+    expect(currentWidth()).toBe(MAX_SIDEBAR_WIDTH);
+  });
+
+  it("widens the sidebar when the handle is dragged right", () => {
+    render(<Harness />);
+
+    drag(DEFAULT_SIDEBAR_WIDTH, DEFAULT_SIDEBAR_WIDTH + 98);
+
+    expect(currentWidth()).toBe(500);
+    expect(cssWidth()).toBe("500px");
+  });
+
+  it("narrows the sidebar when the handle is dragged left", () => {
+    render(<Harness />);
+
+    drag(DEFAULT_SIDEBAR_WIDTH, DEFAULT_SIDEBAR_WIDTH - 102);
+
+    expect(currentWidth()).toBe(300);
+  });
+
+  it("keeps the sidebar at least as wide as the minimum", () => {
+    render(<Harness />);
+
+    drag(DEFAULT_SIDEBAR_WIDTH, 0);
+
+    expect(currentWidth()).toBe(MIN_SIDEBAR_WIDTH);
+  });
+
+  it("keeps the message panel visible when dragged far right", () => {
+    render(<Harness />);
+
+    drag(DEFAULT_SIDEBAR_WIDTH, 5000);
+
+    expect(currentWidth()).toBe(MAX_SIDEBAR_WIDTH);
+  });
+
+  it("persists the width once the drag ends", () => {
+    render(<Harness />);
+
+    drag(DEFAULT_SIDEBAR_WIDTH, DEFAULT_SIDEBAR_WIDTH + 98);
+
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("500");
+  });
+
+  it("ignores drags started with a non-primary button", () => {
+    render(<Harness />);
+
+    fireEvent(
+      separator(),
+      new MouseEvent("pointerdown", {
+        clientX: DEFAULT_SIDEBAR_WIDTH,
+        button: 2,
+        bubbles: true,
+      }),
+    );
+    act(() => {
+      window.dispatchEvent(
+        new MouseEvent("pointermove", { clientX: 600, bubbles: true }),
+      );
+    });
+
+    expect(currentWidth()).toBe(DEFAULT_SIDEBAR_WIDTH);
+  });
+
+  it("resizes with the arrow keys", () => {
+    render(<Harness />);
+
+    fireEvent.keyDown(separator(), { key: "ArrowRight" });
+    expect(currentWidth()).toBe(DEFAULT_SIDEBAR_WIDTH + 16);
+
+    fireEvent.keyDown(separator(), { key: "ArrowLeft" });
+    expect(currentWidth()).toBe(DEFAULT_SIDEBAR_WIDTH);
+  });
+
+  it("takes larger steps when shift is held", () => {
+    render(<Harness />);
+
+    fireEvent.keyDown(separator(), { key: "ArrowRight", shiftKey: true });
+
+    expect(currentWidth()).toBe(DEFAULT_SIDEBAR_WIDTH + 64);
+  });
+
+  it("jumps to the bounds with Home and End", () => {
+    render(<Harness />);
+
+    fireEvent.keyDown(separator(), { key: "Home" });
+    expect(currentWidth()).toBe(MIN_SIDEBAR_WIDTH);
+
+    fireEvent.keyDown(separator(), { key: "End" });
+    expect(currentWidth()).toBe(MAX_SIDEBAR_WIDTH);
+  });
+
+  it("resets to the default width on double click", () => {
+    render(<Harness />);
+
+    fireEvent.keyDown(separator(), { key: "Home" });
+    expect(currentWidth()).toBe(MIN_SIDEBAR_WIDTH);
+
+    fireEvent.doubleClick(separator());
+
+    expect(currentWidth()).toBe(DEFAULT_SIDEBAR_WIDTH);
+  });
+
+  it("restores the chosen width when the viewport grows back", () => {
+    render(<Harness />);
+
+    drag(DEFAULT_SIDEBAR_WIDTH, 600);
+    expect(currentWidth()).toBe(600);
+
+    setViewportWidth(700);
+    expect(currentWidth()).toBe(700 - 320);
+
+    setViewportWidth(1024);
+    expect(currentWidth()).toBe(600);
+  });
+});

--- a/frontend/components/SidebarResizeHandle.tsx
+++ b/frontend/components/SidebarResizeHandle.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import Box from "@mui/material/Box";
+import { SIDEBAR_WIDTH_VAR } from "../hooks/useResizableSidebar";
+
+const HIT_AREA_WIDTH = 12;
+
+type SidebarResizeHandleProps = React.ComponentPropsWithoutRef<"div"> & {
+  resizing: boolean;
+};
+
+const SidebarResizeHandle = ({
+  resizing,
+  ...separatorProps
+}: SidebarResizeHandleProps) => (
+  <Box
+    {...separatorProps}
+    data-resizing={resizing}
+    sx={{
+      position: "fixed",
+      top: 0,
+      bottom: 0,
+      left: `var(${SIDEBAR_WIDTH_VAR})`,
+      width: `${HIT_AREA_WIDTH}px`,
+      marginLeft: `${-HIT_AREA_WIDTH / 2}px`,
+      zIndex: (theme) => theme.zIndex.drawer + 1,
+      display: "flex",
+      justifyContent: "center",
+      cursor: "col-resize",
+      touchAction: "none",
+      "&:focus-visible": {
+        outline: "none",
+      },
+      "&::after": {
+        content: '""',
+        width: "2px",
+        backgroundColor: "transparent",
+        transition: "background-color 120ms ease, width 120ms ease",
+      },
+      "&:hover::after, &[data-resizing='true']::after": {
+        backgroundColor: "primary.main",
+      },
+      "&:focus-visible::after": {
+        width: "4px",
+        backgroundColor: "primary.main",
+      },
+      "@media (prefers-reduced-motion: reduce)": {
+        "&::after": {
+          transition: "none",
+        },
+      },
+    }}
+  />
+);
+
+export default SidebarResizeHandle;

--- a/frontend/hooks/useResizableSidebar.tsx
+++ b/frontend/hooks/useResizableSidebar.tsx
@@ -1,0 +1,168 @@
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+
+export const SIDEBAR_WIDTH_VAR = "--sqs-sidebar-width";
+export const SIDEBAR_CONTAINER = "sqs-sidebar";
+export const DEFAULT_SIDEBAR_WIDTH = 402;
+export const MIN_SIDEBAR_WIDTH = 220;
+export const MAX_SIDEBAR_WIDTH = 640;
+export const MIN_CONTENT_WIDTH = 320;
+
+const STORAGE_KEY = "sqs-admin.sidebarWidth";
+const KEYBOARD_STEP = 16;
+const KEYBOARD_STEP_COARSE = 64;
+
+const maxWidthForViewport = (viewportWidth: number) =>
+  Math.max(
+    MIN_SIDEBAR_WIDTH,
+    Math.min(MAX_SIDEBAR_WIDTH, viewportWidth - MIN_CONTENT_WIDTH),
+  );
+
+const readStoredWidth = () => {
+  try {
+    const stored = Number.parseInt(
+      window.localStorage.getItem(STORAGE_KEY) ?? "",
+      10,
+    );
+    return Number.isFinite(stored) ? stored : DEFAULT_SIDEBAR_WIDTH;
+  } catch {
+    return DEFAULT_SIDEBAR_WIDTH;
+  }
+};
+
+const writeStoredWidth = (width: number) => {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(width));
+  } catch {
+    // Storage is unavailable, so the width only lasts for this session.
+  }
+};
+
+const useResizableSidebar = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [preferredWidth, setPreferredWidth] = useState(readStoredWidth);
+  const [maxWidth, setMaxWidth] = useState(() =>
+    maxWidthForViewport(window.innerWidth),
+  );
+  const [resizing, setResizing] = useState(false);
+
+  const width = Math.min(Math.max(preferredWidth, MIN_SIDEBAR_WIDTH), maxWidth);
+
+  useLayoutEffect(() => {
+    containerRef.current?.style.setProperty(SIDEBAR_WIDTH_VAR, `${width}px`);
+  }, [width]);
+
+  useEffect(() => {
+    const onViewportResize = () =>
+      setMaxWidth(maxWidthForViewport(window.innerWidth));
+    window.addEventListener("resize", onViewportResize);
+    return () => window.removeEventListener("resize", onViewportResize);
+  }, []);
+
+  const commitWidth = useCallback(
+    (next: number) => {
+      const clamped = Math.round(
+        Math.min(Math.max(next, MIN_SIDEBAR_WIDTH), maxWidth),
+      );
+      setPreferredWidth(clamped);
+      writeStoredWidth(clamped);
+    },
+    [maxWidth],
+  );
+
+  const startResize = (event: React.PointerEvent<HTMLElement>) => {
+    if (event.button !== 0) {
+      return;
+    }
+
+    const handle = event.currentTarget;
+    const startX = event.clientX;
+    const startWidth = width;
+    let draft = width;
+
+    handle.setPointerCapture?.(event.pointerId);
+    setResizing(true);
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    const onPointerMove = (moveEvent: PointerEvent) => {
+      draft = Math.round(
+        Math.min(
+          Math.max(startWidth + moveEvent.clientX - startX, MIN_SIDEBAR_WIDTH),
+          maxWidth,
+        ),
+      );
+      containerRef.current?.style.setProperty(SIDEBAR_WIDTH_VAR, `${draft}px`);
+      handle.setAttribute("aria-valuenow", String(draft));
+    };
+
+    const stopResize = () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", stopResize);
+      window.removeEventListener("pointercancel", stopResize);
+      handle.releasePointerCapture?.(event.pointerId);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      setResizing(false);
+      commitWidth(draft);
+    };
+
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", stopResize);
+    window.addEventListener("pointercancel", stopResize);
+  };
+
+  const resizeByKeyboard = (event: React.KeyboardEvent<HTMLElement>) => {
+    const step = event.shiftKey ? KEYBOARD_STEP_COARSE : KEYBOARD_STEP;
+    let next: number;
+
+    switch (event.key) {
+      case "ArrowLeft":
+        next = width - step;
+        break;
+      case "ArrowRight":
+        next = width + step;
+        break;
+      case "Home":
+        next = MIN_SIDEBAR_WIDTH;
+        break;
+      case "End":
+        next = maxWidth;
+        break;
+      case "Enter":
+      case " ":
+        next = DEFAULT_SIDEBAR_WIDTH;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    commitWidth(next);
+  };
+
+  return {
+    width,
+    resizing,
+    containerRef,
+    separatorProps: {
+      role: "separator",
+      tabIndex: 0,
+      "aria-orientation": "vertical" as const,
+      "aria-label": "Resize queue list",
+      "aria-valuenow": width,
+      "aria-valuemin": MIN_SIDEBAR_WIDTH,
+      "aria-valuemax": maxWidth,
+      onPointerDown: startResize,
+      onKeyDown: resizeByKeyboard,
+      onDoubleClick: () => commitWidth(DEFAULT_SIDEBAR_WIDTH),
+    },
+  };
+};
+
+export default useResizableSidebar;

--- a/frontend/views/Overview.tsx
+++ b/frontend/views/Overview.tsx
@@ -26,6 +26,11 @@ import { callApi } from "../api/Http";
 import MessageItem from "../components/MessageItem";
 import QueueIcon from "@mui/icons-material/CalendarViewWeek";
 import Box from "@mui/material/Box";
+import SidebarResizeHandle from "../components/SidebarResizeHandle";
+import useResizableSidebar, {
+  SIDEBAR_CONTAINER,
+  SIDEBAR_WIDTH_VAR,
+} from "../hooks/useResizableSidebar";
 
 const a11yProps = (id: string, index: number) => {
   return {
@@ -41,6 +46,12 @@ const Overview = () => {
   const [error, setError] = useState("");
   const [disabledStatus, setDisabledStatus] = useState(true);
   const [region, setRegion] = useState({ region: "" } as AwsRegion);
+  const {
+    width: sidebarWidth,
+    resizing,
+    containerRef,
+    separatorProps,
+  } = useResizableSidebar();
 
   useInterval(async () => {
     await receiveMessageFromCurrentQueue();
@@ -166,22 +177,27 @@ const Overview = () => {
   };
 
   return (
-    <Box sx={{ display: "flex" }}>
+    <Box
+      ref={containerRef}
+      sx={{ display: "flex", [SIDEBAR_WIDTH_VAR]: `${sidebarWidth}px` }}
+    >
       <Box>
         <Drawer
           sx={{
-            width: 402,
+            width: `var(${SIDEBAR_WIDTH_VAR})`,
             flexShrink: 0,
             "& .MuiDrawer-paper": {
-              width: 402,
+              width: `var(${SIDEBAR_WIDTH_VAR})`,
               boxSizing: "border-box",
+              containerType: "inline-size",
+              containerName: SIDEBAR_CONTAINER,
             },
           }}
           variant="permanent"
           anchor="left"
         >
           <List>
-            <ListItem>
+            <ListItem sx={{ flexWrap: "wrap", columnGap: 1 }}>
               <Typography variant="h6" margin={"auto"}>
                 SQS Admin UI
               </Typography>
@@ -198,6 +214,11 @@ const Overview = () => {
                   gap: 1,
                   display: "grid",
                   gridTemplateColumns: "repeat(2, 1fr)",
+                  [`@container ${SIDEBAR_CONTAINER} (max-width: 340px)`]: {
+                    gridTemplateColumns: "1fr",
+                    paddingLeft: 1,
+                    paddingRight: 1,
+                  },
                 }}
               >
                 <CreateQueueDialog onSubmit={createNewQueue} />
@@ -253,7 +274,8 @@ const Overview = () => {
           </List>
         </Drawer>
       </Box>
-      <Box sx={{ flexGrow: 1 }}>
+      <SidebarResizeHandle resizing={resizing} {...separatorProps} />
+      <Box sx={{ flexGrow: 1, minWidth: 0 }}>
         <Grid size={{ xs: 12 }}>
           <Toolbar>
             <Typography variant="h6" margin={"auto"}>
@@ -290,7 +312,11 @@ const Overview = () => {
             >
               <Grid container spacing={2}>
                 {messages?.map((message, index) => (
-                  <Grid key={index} size={{ xs: 12 }} {...a11yProps("gridItem", index)}>
+                  <Grid
+                    key={index}
+                    size={{ xs: 12 }}
+                    {...a11yProps("gridItem", index)}
+                  >
                     <Paper>
                       <MessageItem
                         key={index}


### PR DESCRIPTION
Closes #1537.

The queue sidebar was fixed at 402px. On a half-screen window (~490px, as in the reported case) that leaves roughly 88px for the message panel — the part of the app people actually read. Dragging the drawer edge now reclaims that space: at 490px the message panel goes from 88px to 270px.

## Behaviour

- Drag the boundary between the sidebar and the message panel. Bounds are 220px to `min(640px, viewport - 320px)`, so the message panel always keeps at least 320px.
- Keyboard operable: arrows step 16px, `Shift`+arrows 64px, `Home`/`End` jump to the bounds, `Enter`/`Space` or a double click resets to the 402px default.
- The width persists in `localStorage`.

## Design notes

**Nothing new at rest.** The 12px hit strip is invisible and sits centred on the drawer's existing border. It becomes a 2px `primary.main` line on hover and 4px on keyboard focus, with a `col-resize` cursor. The default view is pixel-identical to before, which keeps the "minimal and lightweight" promise in the README.

**No new dependency.** `react-resizable-panels` and `allotment` both assume flex panels and fight a fixed-position MUI `Drawer` paper. A hook plus a small component was less weight and gave full control over the a11y surface.

**Dragging does not re-render.** `pointermove` writes `--sqs-sidebar-width` straight to the DOM via a ref; React state and `localStorage` are touched once, on `pointerup`. This matters because the message panel renders a `JSONTree` per message and `useInterval` polls every 3s — a state-per-move implementation would re-render the whole list on every mouse move.

**Container queries, not a width breakpoint.** `container-type: inline-size` on the drawer paper collapses the button grid to one column *during* the drag rather than snapping on release, again with no React involvement.

**`localStorage` holds the preferred width, not the clamped one.** Clamping is applied on top at render. Verified: preference 560 → shrink viewport to 490 → renders 220 → grow to 1100 → back to 560. Storing the clamped value instead would silently destroy the preference on the first shrink.

Also added `minWidth: 0` to the content flex child — without it, long unbreakable JSON strings blow out the flex item, a latent bug that only becomes visible once the panel can get narrow.

## Testing

16 new tests in `SidebarResizeHandle.test.tsx` covering bounds, persistence, corrupted stored values, drag, keyboard, double-click reset, non-primary buttons, and the viewport shrink/grow cycle. Full suite: 61 passed, `tsc --noEmit` clean.

Manually verified against localstack with real queues and messages at 900px, 490px and 1100px viewports: hover wake-up, pointer drag, `Home`, double-click reset, `body` cursor/user-select cleanup on release, no console output, and no horizontal overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)